### PR TITLE
Removed special handling for typographic chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 	
 ### KNOWN BUGS
 - There is no way to log out of the administrator panel. The logged-in user’s session will expire when the browser is closed or one hour has passed since the log in. 
-- Typographic characters are not supported. When editing or adding sites in the adminstrator panel, apostrophes and quotes should be typed directly into the text box and not copied from a word processor.
 
 ## Install  Guide - Version 1.0
 ### PREREQUISITES:

--- a/admin/src/Components/APIHandler.js
+++ b/admin/src/Components/APIHandler.js
@@ -63,11 +63,19 @@ function getImageList(site, callback) {
         .then(callback);
 }
 
+// removes bullet points from description because they are automatically inserted at line breaks
+function parseDescription(description) {
+
+    let bullet_regex = /•/g;
+    description = description.replace(bullet_regex, "");
+    return description;
+}
+
 // POSTs a new site to the database
 function postSite(site, callback) {
     const formData = new FormData();
     formData.append("name", site.name);
-    formData.append("description", site.description);
+    formData.append("description", parseDescription(site.description));
     formData.append("transcript", site.transcript);
     formData.append("latitude", site.position[0]);
     formData.append("longitude", site.position[1]);
@@ -94,7 +102,7 @@ function postSite(site, callback) {
 function putSite(site, callback) {
     const formData = new FormData();
     formData.append("name", site.name);
-    formData.append("description", site.description);
+    formData.append("description", parseDescription(site.description));
     formData.append("transcript", site.transcript);
     formData.append("latitude", site.position[0]);
     formData.append("longitude", site.position[1]);
@@ -223,16 +231,8 @@ function postRouteUpdate(route, callback) {
 // Convert json object to a format that matches what Map expects
 function convertToMapObject(response) {
     let map_response = response.map(({id, name, description, transcript, latitude, longitude, filters, stop_num}) =>
-        ({id, name, description: parseDescription(description), transcript, filters: parseFilters(filters), position: [latitude, longitude], stop_num}));
+        ({id, name, description: description, transcript, filters: parseFilters(filters), position: [latitude, longitude], stop_num}));
     return map_response;
-}
-
-// replaces temp characters with utf ones
-function parseDescription(description) {
-    // perhaps some way to insert newlines to the description?
-    let bullet_dash_regex = /- /g
-    description = description.replace(bullet_dash_regex, "\u2022 ")
-    return description
 }
 
 // converts filters field into a list of filters


### PR DESCRIPTION
Admin panel is able to successfully store all UTF in location descriptions.  Just the SQL script doesn't work. Each location will need to have their info on the live site updated with the direct info from OCS.